### PR TITLE
Adding support for postgres and switching DB type via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A config file is needed, whose contents should look like:
 ```json
 {
 	"DBType":     "sqlite3",
-	"DBPath":     "sqlite:///obmd.db",
+	"DBPath":     "./obmd.db",
 	"ListenAddr": ":8080",
 	"AdminToken": "44d5ebcb1aae23bfefc8dca8314797eb"
 }

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ A config file is needed, whose contents should look like:
 }
 ```
 
-The choices for database type are "sqlite3" and "postgres".
-If using postgres, the DBPath URI might look like:
+The choices for database type are `sqlite3` and `postgres`.
+If using postgres, the DBPath string might look like:
 
-	"postgresql://username:password@localhost:5432/db-name"
+	"host=localhost port=5432 user=username password=pass dbname=obmd"
 
 The admin token should be a (cryptographically randomly generated)
 128-bit value encoded in hexadecimal. You can generate such a token by

--- a/README.md
+++ b/README.md
@@ -16,10 +16,17 @@ A config file is needed, whose contents should look like:
 
 ```json
 {
+	"DBType":     "sqlite3",
+	"DBPath":     "sqlite:///obmd.db",
 	"ListenAddr": ":8080",
 	"AdminToken": "44d5ebcb1aae23bfefc8dca8314797eb"
 }
 ```
+
+The choices for database type are "sqlite3" and "postgres".
+If using postgres, the DBPath URI might look like:
+
+	"postgresql://username:password@localhost:5432/db-name"
 
 The admin token should be a (cryptographically randomly generated)
 128-bit value encoded in hexadecimal. You can generate such a token by

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net/http"
 
+	_ "github.com/lib/pq"
 	_ "github.com/mattn/go-sqlite3"
 
 	"github.com/CCI-MOC/obmd/internal/driver"
@@ -19,15 +20,15 @@ import (
 
 // Contents of the config file
 type Config struct {
+	DBType     string
+	DBPath     string
 	ListenAddr string
 	AdminToken Token
 }
 
 var (
 	configPath = flag.String("config", "config.json", "Path to config file")
-	dbPath     = flag.String("dbpath", ":memory:", "Path to sqlite database")
-
-	genToken = flag.Bool("gen-token", false,
+	genToken   = flag.Bool("gen-token", false,
 		"Generate a random token, instead of starting the daemon.")
 )
 
@@ -56,7 +57,8 @@ func main() {
 	chkfatal(err)
 	var config Config
 	chkfatal(json.Unmarshal(buf, &config))
-	db, err := sql.Open("sqlite3", *dbPath)
+	// DB Types: sqlite3 or postgres
+	db, err := sql.Open(config.DBType, config.DBPath)
 	chkfatal(err)
 	chkfatal(db.Ping())
 

--- a/state.go
+++ b/state.go
@@ -100,7 +100,7 @@ func (s *State) NewNode(label string, info []byte) (*Node, error) {
 	}
 	_, err = s.db.Exec(
 		`INSERT INTO nodes(label, obm_info)
-			VALUES (?, ?)`,
+			VALUES ($1, $2)`,
 		label,
 		info,
 	)
@@ -118,7 +118,7 @@ func (s *State) DeleteNode(label string) error {
 	if ok {
 		node.StopOBM()
 		delete(s.nodes, label)
-		_, err = s.db.Exec("DELETE FROM nodes WHERE label = ?", label)
+		_, err = s.db.Exec("DELETE FROM nodes WHERE label = $1", label)
 	}
 	return err
 }


### PR DESCRIPTION
- Config file now takes a database type and URI.
- `?` replaced with $# format that postrgres supports.
- The error raised when a user enters a wrong DBType is informative enough for a developer but not for a user.  I figured this could be fixed in #8.