### PR TITLE
API call to return a node's power status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 go:
   - 1.8
   - 1.9
-  - 1.10
+  - "1.10"
   - tip
 go_import_path: github.com/CCI-MOC/obmd
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 go:
-  - 1.7
   - 1.8
   - 1.9
+  - 1.10
   - tip
 go_import_path: github.com/CCI-MOC/obmd
 matrix:

--- a/README.md
+++ b/README.md
@@ -184,6 +184,14 @@ Notes:
   * `"disk"`: Boot from local hard disk.
   * `"none"`: Reset boot order to default.
 
+### Checking a node's power status
+
+`GET /node/{node_id}/power_status`
+
+Notes:
+
+* Returns a JSON string that describes the node's power state.
+
 [net.Dial]: https://golang.org/pkg/net/#Dial
 [travis]: https://travis-ci.org/CCI-MOC/obmd
 [travis-img]: https://travis-ci.org/CCI-MOC/obmd.svg?branch=master

--- a/README.md
+++ b/README.md
@@ -188,9 +188,18 @@ Notes:
 
 `GET /node/{node_id}/power_status`
 
+Response body:
+
+```json
+{
+    "power_status": "<IPMI chassis power status response>"
+}
+```
+
 Notes:
 
 * Returns a JSON string that describes the node's power state.
+* Response examples: "Chassis Power is on" or "Chassis Power is off"
 
 [net.Dial]: https://golang.org/pkg/net/#Dial
 [travis]: https://travis-ci.org/CCI-MOC/obmd

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Response body:
 Notes:
 
 * Returns a JSON string that describes the node's power state.
-* Response examples: "Chassis Power is on" or "Chassis Power is off"
+* Response examples: "on" or "off"
 
 [net.Dial]: https://golang.org/pkg/net/#Dial
 [travis]: https://travis-ci.org/CCI-MOC/obmd

--- a/daemon.go
+++ b/daemon.go
@@ -125,12 +125,12 @@ func (d *Daemon) SetNodeBootDev(label string, dev string, token *Token) error {
 	return node.OBM.SetBootdev(dev)
 }
 
-func (d *Daemon) GetNodePowerStatus(label string, token *Token) (io.ReadCloser, error) {
+func (d *Daemon) GetNodePowerStatus(label string, token *Token) (string, error) {
 	d.Lock()
 	defer d.Unlock()
 	node, err := d.getNodeWithToken(label, token)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	return node.OBM.GetPowerStatus()
 }

--- a/daemon.go
+++ b/daemon.go
@@ -124,3 +124,13 @@ func (d *Daemon) SetNodeBootDev(label string, dev string, token *Token) error {
 	}
 	return node.OBM.SetBootdev(dev)
 }
+
+func (d *Daemon) GetNodePowerStatus(label string, token *Token) (io.ReadCloser, error) {
+	d.Lock()
+	defer d.Unlock()
+	node, err := d.getNodeWithToken(label, token)
+	if err != nil {
+		return nil, err
+	}
+	return node.OBM.GetPowerStatus()
+}

--- a/http.go
+++ b/http.go
@@ -205,17 +205,6 @@ func makeHandler(config *Config, daemon *Daemon) http.Handler {
 
 	r.Methods("GET").Path("/node/{node_id}/power_status").
 		Handler(withToken(func(w http.ResponseWriter, req *http.Request, token *Token) {
-			//relayError(w, "daemon.GetNodePowerStatus()", daemon.GetNodePowerStatus(nodeId(req), token))
-			/*status, err := daemon.GetNodePowerStatus(nodeId(req), token)
-			if err != nil {
-				relayError(w, "daemon.GetNodeStatus()", err)
-			} else {
-				w.Header().Set("Content-Type", "application/json")
-				json.NewEncoder(w).Encode(&PowerResp{
-					string: status,
-				})
-			}*/
-
 			conn, err := daemon.GetNodePowerStatus(nodeId(req), token)
 			if err != nil {
 				relayError(w, "daemon.GetNodePowerStatus()", err)

--- a/http.go
+++ b/http.go
@@ -39,7 +39,7 @@ type TokenResp struct {
 
 // Response body for successful node power status requests.
 type PowerResp struct {
-	string string `json:"power_status"`
+	Resp string `json:"power_status"`
 }
 
 func makeHandler(config *Config, daemon *Daemon) http.Handler {
@@ -205,34 +205,15 @@ func makeHandler(config *Config, daemon *Daemon) http.Handler {
 
 	r.Methods("GET").Path("/node/{node_id}/power_status").
 		Handler(withToken(func(w http.ResponseWriter, req *http.Request, token *Token) {
-			conn, err := daemon.GetNodePowerStatus(nodeId(req), token)
+			status, err := daemon.GetNodePowerStatus(nodeId(req), token)
 			if err != nil {
 				relayError(w, "daemon.GetNodePowerStatus()", err)
 			} else {
-				defer conn.Close()
-				w.Header().Set("Content-Type", "application/octet-stream")
-
-				// Copy stream to the client. Unfortunately we can't just use
-				// io.Copy here, because we need to call Flush() between writes.
-				// otherwise, the client won't receive console data in a timely
-				// manner, because the ResponseWriter may buffer it.
-				var buf [4096]byte
-				for err == nil {
-					var n int
-					n, err = conn.Read(buf[:])
-					if n != 0 {
-						_, err = w.Write(buf[:n])
-					}
-					if flusher, ok := w.(http.Flusher); ok {
-						flusher.Flush()
-					}
-				}
-
-				if err != io.EOF {
-					log.Println("Error reading from console:", err)
-				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(&PowerResp{
+					Resp: status,
+				})
 			}
 		}))
-
 	return r
 }

--- a/internal/driver/coordinator/coordinator.go
+++ b/internal/driver/coordinator/coordinator.go
@@ -22,6 +22,7 @@ type OBM interface {
 	// Connect to the console, returning the managing Proc and an
 	// error, if any.
 	Dial() (Proc, error)
+	GetPowerStatus() (Proc, error)
 }
 
 // A request to connect to the console. If the request succeeds, the connection
@@ -62,7 +63,8 @@ type Server struct {
 	dropConsole chan struct{}
 
 	// Requests to connect to the console.
-	dialConsole chan consoleReq
+	dialConsole    chan consoleReq
+	getPowerStatus chan consoleReq
 
 	// Requests to run a function atomically within the server.
 	funcs chan func()
@@ -121,6 +123,21 @@ func (s *Server) Serve(ctx context.Context) {
 				Reader: proc.Reader(),
 			}
 			req.conn <- conn
+		case req := <-s.getPowerStatus:
+			stopProcess()
+			proc, err = s.obm.GetPowerStatus()
+			if err != nil {
+				req.err <- err
+				continue
+			}
+			conn = &consoleConn{
+				// Buffer size of 1, so calls to Close() on the connection
+				// don't block. Otherwise, if we've already dropped the
+				// connection, Close() would deadlock.
+				drop:   make(chan struct{}, 1),
+				Reader: proc.Reader(),
+			}
+			req.conn <- conn
 		}
 	}
 }
@@ -128,10 +145,11 @@ func (s *Server) Serve(ctx context.Context) {
 // Create a Server for the given OBM.
 func NewServer(obm OBM) *Server {
 	return &Server{
-		obm:         obm,
-		dropConsole: make(chan struct{}),
-		dialConsole: make(chan consoleReq),
-		funcs:       make(chan func()),
+		obm:            obm,
+		dropConsole:    make(chan struct{}),
+		dialConsole:    make(chan consoleReq),
+		getPowerStatus: make(chan consoleReq),
+		funcs:          make(chan func()),
 	}
 }
 
@@ -148,6 +166,20 @@ func (s *Server) DialConsole() (io.ReadCloser, error) {
 		conn: make(chan io.ReadCloser),
 	}
 	s.dialConsole <- req
+	select {
+	case err := <-req.err:
+		return nil, err
+	case conn := <-req.conn:
+		return conn, nil
+	}
+}
+
+func (s *Server) GetPowerStatus() (io.ReadCloser, error) {
+	req := consoleReq{
+		err:  make(chan error),
+		conn: make(chan io.ReadCloser),
+	}
+	s.getPowerStatus <- req
 	select {
 	case err := <-req.err:
 		return nil, err

--- a/internal/driver/dummy/dummy.go
+++ b/internal/driver/dummy/dummy.go
@@ -76,16 +76,7 @@ func (d *dummyOBM) SetBootdev(dev string) error {
 	return nil
 }
 
-func (d *dummyOBM) GetPowerStatus() (io.ReadCloser, error) {
-	conn, err := net.Dial("tcp", d.Addr)
-	if err != nil {
-		return nil, err
-	}
-	_, err = fmt.Fprintln(conn, d)
-	if err != nil {
-		conn.Close()
-		return nil, err
-	}
-	d.conn = conn
-	return conn, nil
+func (d *dummyOBM) GetPowerStatus() (string, error) {
+	log.Printf("Status = %v: %v\n", "Dummy Status", d)
+	return "Dummy Status", nil
 }

--- a/internal/driver/dummy/dummy.go
+++ b/internal/driver/dummy/dummy.go
@@ -62,7 +62,7 @@ func (d *dummyOBM) DialConsole() (io.ReadCloser, error) {
 }
 
 func (d *dummyOBM) PowerOff() error {
-	log.Println("Powering off:", d)
+	log.Println("Powering off: %v", d)
 	return nil
 }
 
@@ -74,4 +74,18 @@ func (d *dummyOBM) PowerCycle(force bool) error {
 func (d *dummyOBM) SetBootdev(dev string) error {
 	log.Printf("Setting bootdev = %v: %v\n", dev, d)
 	return nil
+}
+
+func (d *dummyOBM) GetPowerStatus() (io.ReadCloser, error) {
+	conn, err := net.Dial("tcp", d.Addr)
+	if err != nil {
+		return nil, err
+	}
+	_, err = fmt.Fprintln(conn, d)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+	d.conn = conn
+	return conn, nil
 }

--- a/internal/driver/dummy/dummy.go
+++ b/internal/driver/dummy/dummy.go
@@ -23,6 +23,7 @@ type dummyDriver struct {
 func (dummyDriver) GetOBM(info []byte) (driver.OBM, error) {
 	ret := dummyOBM{}
 	err := json.Unmarshal(info, &ret)
+	ret.PwrStatus = "off"
 	if err != nil {
 		return nil, err
 	}
@@ -30,8 +31,9 @@ func (dummyDriver) GetOBM(info []byte) (driver.OBM, error) {
 }
 
 type dummyOBM struct {
-	Addr string   `json:"addr"`
-	conn net.Conn `json:"-"`
+	Addr      string   `json:"addr"`
+	conn      net.Conn `json:"-"`
+	PwrStatus string
 }
 
 func (d *dummyOBM) Serve(ctx context.Context) {
@@ -62,12 +64,14 @@ func (d *dummyOBM) DialConsole() (io.ReadCloser, error) {
 }
 
 func (d *dummyOBM) PowerOff() error {
-	log.Println("Powering off: %v", d)
+	log.Println("Powering off:", d)
+	d.PwrStatus = "off"
 	return nil
 }
 
 func (d *dummyOBM) PowerCycle(force bool) error {
-	log.Printf("Powering off: %v (force = %v)\n", d, force)
+	log.Printf("Power cycling: %v (force = %v)\n", d, force)
+	d.PwrStatus = "on"
 	return nil
 }
 
@@ -77,6 +81,6 @@ func (d *dummyOBM) SetBootdev(dev string) error {
 }
 
 func (d *dummyOBM) GetPowerStatus() (string, error) {
-	log.Printf("Status = %v: %v\n", "Dummy Status", d)
-	return "Dummy Status", nil
+	log.Printf("Status = %v: %v\n", d.PwrStatus, d)
+	return d.PwrStatus, nil
 }

--- a/internal/driver/interfaces.go
+++ b/internal/driver/interfaces.go
@@ -30,7 +30,7 @@ type OBM interface {
 	SetBootdev(dev string) error
 
 	// Gets the node's power status.
-	GetPowerStatus() (io.ReadCloser, error)
+	GetPowerStatus() (string, error)
 }
 
 // A driver for a type of OBM.

--- a/internal/driver/interfaces.go
+++ b/internal/driver/interfaces.go
@@ -28,9 +28,12 @@ type OBM interface {
 	// Sets the next boot device to `dev`. Valid boot devices are
 	// driver-dependent.
 	SetBootdev(dev string) error
+
+	// Gets the node's power status.
+	GetPowerStatus() (io.ReadCloser, error)
 }
 
-// An driver for a type of OBM.
+// A driver for a type of OBM.
 type Driver interface {
 	// Get an obm object based on the provided info.
 	GetOBM(info []byte) (OBM, error)

--- a/internal/driver/ipmi/ipmi.go
+++ b/internal/driver/ipmi/ipmi.go
@@ -164,9 +164,9 @@ func (s *server) SetBootdev(dev string) error {
 }
 
 // Get the server's power status. Connection similar to dialing the console
-func (info *connInfo) GetPowerStatus() (coordinator.Proc, error) {
-	cmd := info.ipmitool("chassis", "power", "status")
-	stdio, err := pty.Start(cmd)
+func (s *server) GetPowerStatus() (string, error) {
+	// cmd := info.ipmitool("chassis", "power", "status")
+	/*stdio, err := pty.Start(cmd)
 	if err != nil {
 		return nil, err
 	}
@@ -174,6 +174,14 @@ func (info *connInfo) GetPowerStatus() (coordinator.Proc, error) {
 		conn: stdio,
 		proc: cmd.Process,
 		info: info,
-	}, nil
-	//return s.ipmitool("chassis", "power", "status")
+	}, nil*/
+	var status string
+	var errormsg error
+	s.RunInServer(func() {
+		out, err := s.info.ipmitool("chassis", "power", "status").Output()
+		output := string(out)
+		status = output
+		errormsg = err
+	})
+	return status, errormsg
 }

--- a/internal/driver/ipmi/ipmi.go
+++ b/internal/driver/ipmi/ipmi.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strings"
 	"syscall"
 	"time"
 
@@ -168,7 +169,12 @@ func (s *server) GetPowerStatus() (status string, err error) {
 	s.RunInServer(func() {
 		var out []byte
 		out, err = s.info.ipmitool("chassis", "power", "status").Output()
-		status = string(out)
+
+		if strings.HasSuffix(string(out), "on") {
+			status = "on"
+		} else {
+			status = "off"
+		}
 	})
 	return
 }

--- a/internal/driver/ipmi/ipmi.go
+++ b/internal/driver/ipmi/ipmi.go
@@ -163,18 +163,8 @@ func (s *server) SetBootdev(dev string) error {
 	return s.ipmitool("chassis", "bootdev", dev, "options=persistent")
 }
 
-// Get the server's power status. Connection similar to dialing the console
+// Get the server's power status as a string.
 func (s *server) GetPowerStatus() (string, error) {
-	// cmd := info.ipmitool("chassis", "power", "status")
-	/*stdio, err := pty.Start(cmd)
-	if err != nil {
-		return nil, err
-	}
-	return &ipmitoolProcess{
-		conn: stdio,
-		proc: cmd.Process,
-		info: info,
-	}, nil*/
 	var status string
 	var errormsg error
 	s.RunInServer(func() {

--- a/internal/driver/ipmi/ipmi.go
+++ b/internal/driver/ipmi/ipmi.go
@@ -164,14 +164,11 @@ func (s *server) SetBootdev(dev string) error {
 }
 
 // Get the server's power status as a string.
-func (s *server) GetPowerStatus() (string, error) {
-	var status string
-	var errormsg error
+func (s *server) GetPowerStatus() (status string, err error) {
 	s.RunInServer(func() {
-		out, err := s.info.ipmitool("chassis", "power", "status").Output()
-		output := string(out)
-		status = output
-		errormsg = err
+		var out []byte
+		out, err = s.info.ipmitool("chassis", "power", "status").Output()
+		status = string(out)
 	})
-	return status, errormsg
+	return
 }

--- a/internal/driver/ipmi/ipmi.go
+++ b/internal/driver/ipmi/ipmi.go
@@ -163,7 +163,7 @@ func (s *server) SetBootdev(dev string) error {
 	return s.ipmitool("chassis", "bootdev", dev, "options=persistent")
 }
 
-// Get the server's power status.
+// Get the server's power status. Connection similar to dialing the console
 func (info *connInfo) GetPowerStatus() (coordinator.Proc, error) {
 	cmd := info.ipmitool("chassis", "power", "status")
 	stdio, err := pty.Start(cmd)

--- a/internal/driver/ipmi/ipmi.go
+++ b/internal/driver/ipmi/ipmi.go
@@ -162,3 +162,18 @@ func (s *server) SetBootdev(dev string) error {
 	}
 	return s.ipmitool("chassis", "bootdev", dev, "options=persistent")
 }
+
+// Get the server's power status.
+func (info *connInfo) GetPowerStatus() (coordinator.Proc, error) {
+	cmd := info.ipmitool("chassis", "power", "status")
+	stdio, err := pty.Start(cmd)
+	if err != nil {
+		return nil, err
+	}
+	return &ipmitoolProcess{
+		conn: stdio,
+		proc: cmd.Process,
+		info: info,
+	}, nil
+	//return s.ipmitool("chassis", "power", "status")
+}

--- a/internal/driver/mock/mock.go
+++ b/internal/driver/mock/mock.go
@@ -100,24 +100,8 @@ func (s *server) setPowerAction(action PowerAction) {
 	LastPowerActions[s.info.Addr] = action
 }
 
-func (info *mockInfo) GetPowerStatus() (coordinator.Proc, error) {
-	myConn, theirConn := net.Pipe()
-
-	done := make(chan struct{})
-
-	go func() {
-		var err error
-		for err == nil {
-			_, err = fmt.Fprintf(myConn, "%d\n", info.NumWrites)
-			info.NumWrites++
-		}
-		done <- struct{}{}
-	}()
-
-	return &proc{
-		done: done,
-		conn: theirConn,
-	}, nil
+func (s *server) GetPowerStatus() (string, error) {
+	return "Mock Status", nil
 }
 
 func (s *server) PowerOff() error {

--- a/internal/driver/mock/mock.go
+++ b/internal/driver/mock/mock.go
@@ -100,6 +100,26 @@ func (s *server) setPowerAction(action PowerAction) {
 	LastPowerActions[s.info.Addr] = action
 }
 
+func (info *mockInfo) GetPowerStatus() (coordinator.Proc, error) {
+	myConn, theirConn := net.Pipe()
+
+	done := make(chan struct{})
+
+	go func() {
+		var err error
+		for err == nil {
+			_, err = fmt.Fprintf(myConn, "%d\n", info.NumWrites)
+			info.NumWrites++
+		}
+		done <- struct{}{}
+	}()
+
+	return &proc{
+		done: done,
+		conn: theirConn,
+	}, nil
+}
+
 func (s *server) PowerOff() error {
 	s.setPowerAction(Off)
 	return nil

--- a/server_test.go
+++ b/server_test.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 	"time"
 
@@ -160,9 +159,9 @@ func TestPowerStatus(t *testing.T) {
 	request := requestSpec{"GET",
 		"http://localhost/node/somenode/power_status", ""}
 	resp := tokenReq(handler, token, request)
-	body, _ := ioutil.ReadAll(resp.Body)
-	val := strings.Compare(string(body), testStringOff)
-	if val != 0 {
+	body, err := ioutil.ReadAll(resp.Body)
+	errpanic(err)
+	if string(body) != testStringOff {
 		t.Fatalf("GetPowerStatus: Incorrect power status; "+
 			"wanted %v but got %v.", testStringOff, string(body))
 	}
@@ -173,16 +172,17 @@ func TestPowerStatus(t *testing.T) {
 	}
 	// Power on ...
 	resp = tokenReq(handler, token, request)
-	body, _ = ioutil.ReadAll(resp.Body)
+	body, err = ioutil.ReadAll(resp.Body)
+	errpanic(err)
 
 	// Get power status ...
 	request = requestSpec{"GET",
 		"http://localhost/node/somenode/power_status", ""}
 	resp = tokenReq(handler, token, request)
-	body, _ = ioutil.ReadAll(resp.Body)
+	body, err = ioutil.ReadAll(resp.Body)
+	errpanic(err)
 
-	val = strings.Compare(string(body), testStringOn)
-	if val != 0 {
+	if string(body) != testStringOn {
 		t.Fatalf("GetPowerStatus: Incorrect power status; "+
 			"wanted %v but got %v.", testStringOn, string(body))
 	}
@@ -193,16 +193,17 @@ func TestPowerStatus(t *testing.T) {
 	}
 	// Power off ...
 	resp = tokenReq(handler, token, request)
-	body, _ = ioutil.ReadAll(resp.Body)
+	body, err = ioutil.ReadAll(resp.Body)
+	errpanic(err)
 
 	// Get power status ...
 	request = requestSpec{"GET",
 		"http://localhost/node/somenode/power_status", ""}
 	resp = tokenReq(handler, token, request)
-	body, _ = ioutil.ReadAll(resp.Body)
+	body, err = ioutil.ReadAll(resp.Body)
+	errpanic(err)
 
-	val = strings.Compare(string(body), testStringOff)
-	if val != 0 {
+	if string(body) != testStringOff {
 		t.Fatalf("GetPowerStatus: Incorrect power status; "+
 			"wanted %v but got %v.", testStringOff, string(body))
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -5,8 +5,10 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -138,6 +140,73 @@ func TestViewConsole(t *testing.T) {
 			"what was read by the second reader:",
 			readsFirst, "vs.", readsSecond)
 	}
+}
+
+func TestPowerStatus(t *testing.T) {
+	handler := newHandler()
+	makeNode(t, handler, "somenode", `{
+		"type": "dummy",
+		"info": {
+			"addr": "10.0.0.3",
+			"user": "ipmiuser",
+			"pass": "secret"
+		}
+	}`)
+	token := getToken(t, handler, "somenode")
+	testStringOn := string("{\"power_status\":\"on\"}\n")
+	testStringOff := string("{\"power_status\":\"off\"}\n")
+
+	// First make sure dummy node is off
+	request := requestSpec{"GET",
+		"http://localhost/node/somenode/power_status", ""}
+	resp := tokenReq(handler, token, request)
+	body, _ := ioutil.ReadAll(resp.Body)
+	val := strings.Compare(string(body), testStringOff)
+	if val != 0 {
+		t.Fatalf("GetPowerStatus: Incorrect power status; "+
+			"wanted %v but got %v.", testStringOff, string(body))
+	}
+
+	// Now test powering on
+	request = requestSpec{"POST",
+		"http://localhost/node/somenode/power_cycle", `{"force": false}`,
+	}
+	// Power on ...
+	resp = tokenReq(handler, token, request)
+	body, _ = ioutil.ReadAll(resp.Body)
+
+	// Get power status ...
+	request = requestSpec{"GET",
+		"http://localhost/node/somenode/power_status", ""}
+	resp = tokenReq(handler, token, request)
+	body, _ = ioutil.ReadAll(resp.Body)
+
+	val = strings.Compare(string(body), testStringOn)
+	if val != 0 {
+		t.Fatalf("GetPowerStatus: Incorrect power status; "+
+			"wanted %v but got %v.", testStringOn, string(body))
+	}
+
+	// Now test powering off
+	request = requestSpec{"POST",
+		"http://localhost/node/somenode/power_off", "",
+	}
+	// Power off ...
+	resp = tokenReq(handler, token, request)
+	body, _ = ioutil.ReadAll(resp.Body)
+
+	// Get power status ...
+	request = requestSpec{"GET",
+		"http://localhost/node/somenode/power_status", ""}
+	resp = tokenReq(handler, token, request)
+	body, _ = ioutil.ReadAll(resp.Body)
+
+	val = strings.Compare(string(body), testStringOff)
+	if val != 0 {
+		t.Fatalf("GetPowerStatus: Incorrect power status; "+
+			"wanted %v but got %v.", testStringOff, string(body))
+	}
+
 }
 
 func TestPowerActions(t *testing.T) {


### PR DESCRIPTION
- Addresses #12 
- API call returns a JSON string that describes the node's power status
- Requesting the power_status is a non-administrator command.