### PR TITLE
Configurable HTTPS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ A config file is needed, whose contents should look like:
 	"DBPath":     	"./obmd.db",
 	"ListenAddr": 	":8080",
 	"AdminToken": 	"44d5ebcb1aae23bfefc8dca8314797eb",
-	"WebProtocol": 	"https",
 	"TLSCert":	"server.crt",
 	"TLSKey":	"server.key"
 }
@@ -37,8 +36,11 @@ running:
 
     ./console-service -gen-token
 
-The OBMd web protocol can be "http" or "https".  If https is chosen,
-the "TLSCert" and "TLSKey" fields must be filled in.
+By default, OBMd listens for connections via https. While production
+environments should *never* change this, it can be convenient for
+development to make OBMd listen via plaintext http. To do this, add an
+option `"Insecure": true` in the config file, and remove the `TLSCert`
+and `TLSKey` options.
 
 By default, the server looks for the config file at `./config.json`, but
 the `-config` command line option can be used to override this.

--- a/README.md
+++ b/README.md
@@ -16,10 +16,13 @@ A config file is needed, whose contents should look like:
 
 ```json
 {
-	"DBType":     "sqlite3",
-	"DBPath":     "./obmd.db",
-	"ListenAddr": ":8080",
-	"AdminToken": "44d5ebcb1aae23bfefc8dca8314797eb"
+	"DBType":     	"sqlite3",
+	"DBPath":     	"./obmd.db",
+	"ListenAddr": 	":8080",
+	"AdminToken": 	"44d5ebcb1aae23bfefc8dca8314797eb",
+	"WebProtocol": 	"https",
+	"TLSCert":	"server.crt",
+	"TLSKey":	"server.key"
 }
 ```
 
@@ -33,6 +36,9 @@ The admin token should be a (cryptographically randomly generated)
 running:
 
     ./console-service -gen-token
+
+The OBMd web protocol can be "http" or "https".  If https is chosen,
+the "TLSCert" and "TLSKey" fields must be filled in.
 
 By default, the server looks for the config file at `./config.json`, but
 the `-config` command line option can be used to override this.


### PR DESCRIPTION
Addresses #14:

Adds configurable HTTPS support to OBMd.  Users will need to generate their own `.crt` and `.key` files.  I'm assuming users can figure out how to generate those, but we can put it in the docs if need be.

Documentation has been updated as well.