### PR TITLE
Detect client disconnects more reliably.

### DIFF
--- a/http.go
+++ b/http.go
@@ -149,7 +149,16 @@ func makeHandler(config *Config, daemon *Daemon) http.Handler {
 			if err != nil {
 				relayError(w, "daemon.DialNodeConsole()", err)
 			} else {
-				defer conn.Close()
+				go func() {
+					// Close the obm connection if the client closes the http
+					// connection. We can't just defer conn.Close(), because if
+					// Read blocks, the caller we won't find out that the http
+					// connection is closed until it returns (and then calls
+					// Write, which returns an error).
+					<-req.Context().Done()
+					conn.Close()
+				}()
+
 				w.Header().Set("Content-Type", "application/octet-stream")
 
 				// Copy stream to the client. Unfortunately we can't just use

--- a/http.go
+++ b/http.go
@@ -152,7 +152,7 @@ func makeHandler(config *Config, daemon *Daemon) http.Handler {
 				go func() {
 					// Close the obm connection if the client closes the http
 					// connection. We can't just defer conn.Close(), because if
-					// Read blocks, the caller we won't find out that the http
+					// Read blocks, the caller won't find out that the http
 					// connection is closed until it returns (and then calls
 					// Write, which returns an error).
 					<-req.Context().Done()


### PR DESCRIPTION
See the comment. @naved001 reported that impitool processes were
persisting after disconnects; this is only a guess as to the problem, it
needs testing.

Naved, can you try this out and let me know if it fixes the problem?