### PR TITLE
Sanity check config file for insufficiently restrictive permissions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,10 @@ option `"Insecure": true` in the config file, and remove the `TLSCert`
 and `TLSKey` options.
 
 By default, the server looks for the config file at `./config.json`, but
-the `-config` command line option can be used to override this.
+the `-config` command line option can be used to override this. OBMd
+will refuse to run if the file's permissions are such that any use other
+than the owner may access the file; this is a sanity check for insecure
+configurations, as the file contains sensitive information.
 
 # Api
 

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"os"
 
 	_ "github.com/lib/pq"
 	_ "github.com/mattn/go-sqlite3"
@@ -56,6 +57,17 @@ func main() {
 		chkfatal(err)
 		fmt.Println(string(text))
 		return
+	}
+
+	fi, err := os.Stat(*configPath)
+	if err != nil {
+		log.Fatal("Error reading config file:", err)
+	}
+	if fi.Mode().Perm()&0077 != 0 {
+		log.Fatalf(
+			"Error: permissions on %q are too permissive; make "+
+				"sure only the obmd user may access the file.",
+			*configPath)
 	}
 
 	buf, err := ioutil.ReadFile(*configPath)


### PR DESCRIPTION
Probably should do this with HIL, too.