### PR TITLE
Move the token stuff into its own package.

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -69,8 +69,7 @@ func (d *Daemon) InvalidateNodeToken(label string) error {
 	if err != nil {
 		return err
 	}
-	node.ClearToken()
-	return nil
+	return node.ClearToken()
 }
 
 // Get the node with the specified label, and check that `token` is valid for it.

--- a/daemon.go
+++ b/daemon.go
@@ -72,7 +72,7 @@ func (d *Daemon) InvalidateNodeToken(label string) error {
 	return node.ClearToken()
 }
 
-// Get the node with the specified label, and check that `token` is valid for it.
+// Get the node with the specified label, and check that `tok` is valid for it.
 // Returns an error if the node does not exist or token is invalid.
 func (d *Daemon) getNodeWithToken(label string, tok *token.Token) (*Node, error) {
 	node, err := d.state.GetNode(label)
@@ -85,59 +85,59 @@ func (d *Daemon) getNodeWithToken(label string, tok *token.Token) (*Node, error)
 	return node, nil
 }
 
-func (d *Daemon) usingNodeWithToken(label string, token *token.Token,
+func (d *Daemon) usingNodeWithToken(label string, tok *token.Token,
 	f func(*Node) error) error {
 	d.Lock()
 	defer d.Unlock()
-	node, err := d.getNodeWithToken(label, token)
+	node, err := d.getNodeWithToken(label, tok)
 	if err != nil {
 		return err
 	}
 	return f(node)
 }
 
-func (d *Daemon) DialNodeConsole(label string, token *token.Token) (io.ReadCloser, error) {
+func (d *Daemon) DialNodeConsole(label string, tok *token.Token) (io.ReadCloser, error) {
 	d.Lock()
 	defer d.Unlock()
-	node, err := d.getNodeWithToken(label, token)
+	node, err := d.getNodeWithToken(label, tok)
 	if err != nil {
 		return nil, err
 	}
 	return node.OBM.DialConsole()
 }
 
-func (d *Daemon) PowerOnNode(label string, token *token.Token) error {
-	return d.usingNodeWithToken(label, token, func(n *Node) error {
+func (d *Daemon) PowerOnNode(label string, tok *token.Token) error {
+	return d.usingNodeWithToken(label, tok, func(n *Node) error {
 		return n.OBM.PowerOn()
 	})
 }
 
-func (d *Daemon) PowerOffNode(label string, token *token.Token) error {
-	return d.usingNodeWithToken(label, token, func(n *Node) error {
+func (d *Daemon) PowerOffNode(label string, tok *token.Token) error {
+	return d.usingNodeWithToken(label, tok, func(n *Node) error {
 		return n.OBM.PowerOff()
 	})
 }
 
-func (d *Daemon) PowerCycleNode(label string, force bool, token *token.Token) error {
-	return d.usingNodeWithToken(label, token, func(n *Node) error {
+func (d *Daemon) PowerCycleNode(label string, force bool, tok *token.Token) error {
+	return d.usingNodeWithToken(label, tok, func(n *Node) error {
 		return n.OBM.PowerCycle(force)
 	})
 }
 
-func (d *Daemon) SetNodeBootDev(label string, dev string, token *token.Token) error {
+func (d *Daemon) SetNodeBootDev(label string, dev string, tok *token.Token) error {
 	d.Lock()
 	defer d.Unlock()
-	node, err := d.getNodeWithToken(label, token)
+	node, err := d.getNodeWithToken(label, tok)
 	if err != nil {
 		return err
 	}
 	return node.OBM.SetBootdev(dev)
 }
 
-func (d *Daemon) GetNodePowerStatus(label string, token *token.Token) (string, error) {
+func (d *Daemon) GetNodePowerStatus(label string, tok *token.Token) (string, error) {
 	d.Lock()
 	defer d.Unlock()
-	node, err := d.getNodeWithToken(label, token)
+	node, err := d.getNodeWithToken(label, tok)
 	if err != nil {
 		return "", err
 	}

--- a/http.go
+++ b/http.go
@@ -110,13 +110,13 @@ func makeHandler(config *Config, daemon *Daemon) http.Handler {
 
 	adminR.Methods("POST").Path("/node/{node_id}/token").
 		HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			token, err := daemon.GetNodeToken(nodeId(req))
+			tok, err := daemon.GetNodeToken(nodeId(req))
 			if err != nil {
 				relayError(w, "daemon.GetNodeToken()", err)
 			} else {
 				w.Header().Set("Content-Type", "application/json")
 				json.NewEncoder(w).Encode(&TokenResp{
-					Token: token,
+					Token: tok,
 				})
 			}
 		})

--- a/http.go
+++ b/http.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"crypto/subtle"
 	"encoding/json"
 	"io"
 	"io/ioutil"
@@ -87,7 +86,7 @@ func makeHandler(config *Config, daemon *Daemon) http.Handler {
 		if err != nil {
 			return false
 		}
-		return subtle.ConstantTimeCompare(tok[:], config.AdminToken[:]) == 1
+		return config.AdminToken.Verify(tok) == nil
 	}).Subrouter()
 
 	// ------ Admin-only requests ------

--- a/http.go
+++ b/http.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/CCI-MOC/obmd/internal/driver"
+	"github.com/CCI-MOC/obmd/token"
 )
 
 // request body for the power cycle call
@@ -34,7 +35,7 @@ type ConnInfo struct {
 
 // Response body for successful new token requests.
 type TokenResp struct {
-	Token Token `json:"token"`
+	Token token.Token `json:"token"`
 }
 
 // Response body for successful node power status requests.
@@ -55,7 +56,7 @@ func makeHandler(config *Config, daemon *Daemon) http.Handler {
 			w.WriteHeader(http.StatusOK)
 		case ErrNoSuchNode:
 			w.WriteHeader(http.StatusNotFound)
-		case ErrInvalidToken:
+		case token.ErrInvalidToken:
 			w.WriteHeader(http.StatusUnauthorized)
 		case driver.ErrInvalidBootdev:
 			w.WriteHeader(http.StatusBadRequest)
@@ -81,7 +82,7 @@ func makeHandler(config *Config, daemon *Daemon) http.Handler {
 		if !(ok && user == "admin") {
 			return false
 		}
-		var tok Token
+		var tok token.Token
 		err := (&tok).UnmarshalText([]byte(pass))
 		if err != nil {
 			return false
@@ -131,21 +132,21 @@ func makeHandler(config *Config, daemon *Daemon) http.Handler {
 
 	// Helper which extracts the token from the query string, and passes it to the "real"
 	// handler. Note that this doesn't check the validity of the token, merely parses it.
-	withToken := func(handler func(http.ResponseWriter, *http.Request, *Token)) http.Handler {
+	withToken := func(handler func(http.ResponseWriter, *http.Request, *token.Token)) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			var token Token
-			err := (&token).UnmarshalText([]byte(req.URL.Query().Get("token")))
+			var tok token.Token
+			err := (&tok).UnmarshalText([]byte(req.URL.Query().Get("token")))
 			if err != nil {
 				relayError(w, "getToken()", err)
 				return
 			}
-			handler(w, req, &token)
+			handler(w, req, &tok)
 		})
 	}
 
 	r.Methods("GET").Path("/node/{node_id}/console").
-		Handler(withToken(func(w http.ResponseWriter, req *http.Request, token *Token) {
-			conn, err := daemon.DialNodeConsole(nodeId(req), token)
+		Handler(withToken(func(w http.ResponseWriter, req *http.Request, tok *token.Token) {
+			conn, err := daemon.DialNodeConsole(nodeId(req), tok)
 			if err != nil {
 				relayError(w, "daemon.DialNodeConsole()", err)
 			} else {
@@ -184,42 +185,42 @@ func makeHandler(config *Config, daemon *Daemon) http.Handler {
 		}))
 
 	r.Methods("POST").Path("/node/{node_id}/power_cycle").
-		Handler(withToken(func(w http.ResponseWriter, req *http.Request, token *Token) {
+		Handler(withToken(func(w http.ResponseWriter, req *http.Request, tok *token.Token) {
 			var args PowerCycleArgs
 			err := json.NewDecoder(req.Body).Decode(&args)
 			if err != nil {
 				w.WriteHeader(http.StatusBadRequest)
 				return
 			}
-			err = daemon.PowerCycleNode(nodeId(req), args.Force, token)
+			err = daemon.PowerCycleNode(nodeId(req), args.Force, tok)
 			relayError(w, "daemon.PowerCycleNode()", err)
 		}))
 
 	r.Methods("POST").Path("/node/{node_id}/power_on").
-		Handler(withToken(func(w http.ResponseWriter, req *http.Request, token *Token) {
-			relayError(w, "daemon.PowerOn()", daemon.PowerOnNode(nodeId(req), token))
+		Handler(withToken(func(w http.ResponseWriter, req *http.Request, tok *token.Token) {
+			relayError(w, "daemon.PowerOn()", daemon.PowerOnNode(nodeId(req), tok))
 		}))
 
 	r.Methods("POST").Path("/node/{node_id}/power_off").
-		Handler(withToken(func(w http.ResponseWriter, req *http.Request, token *Token) {
-			relayError(w, "daemon.PowerOff()", daemon.PowerOffNode(nodeId(req), token))
+		Handler(withToken(func(w http.ResponseWriter, req *http.Request, tok *token.Token) {
+			relayError(w, "daemon.PowerOff()", daemon.PowerOffNode(nodeId(req), tok))
 		}))
 
 	r.Methods("PUT").Path("/node/{node_id}/boot_device").
-		Handler(withToken(func(w http.ResponseWriter, req *http.Request, token *Token) {
+		Handler(withToken(func(w http.ResponseWriter, req *http.Request, tok *token.Token) {
 			var args SetBootdevArgs
 			err := json.NewDecoder(req.Body).Decode(&args)
 			if err != nil {
 				w.WriteHeader(http.StatusBadRequest)
 				return
 			}
-			err = daemon.SetNodeBootDev(nodeId(req), args.Dev, token)
+			err = daemon.SetNodeBootDev(nodeId(req), args.Dev, tok)
 			relayError(w, "daemon.SetNodeBootDev()", err)
 		}))
 
 	r.Methods("GET").Path("/node/{node_id}/power_status").
-		Handler(withToken(func(w http.ResponseWriter, req *http.Request, token *Token) {
-			status, err := daemon.GetNodePowerStatus(nodeId(req), token)
+		Handler(withToken(func(w http.ResponseWriter, req *http.Request, tok *token.Token) {
+			status, err := daemon.GetNodePowerStatus(nodeId(req), tok)
 			if err != nil {
 				relayError(w, "daemon.GetNodePowerStatus()", err)
 			} else {

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/CCI-MOC/obmd/internal/driver/dummy"
 	"github.com/CCI-MOC/obmd/internal/driver/ipmi"
 	"github.com/CCI-MOC/obmd/internal/driver/mock"
+	"github.com/CCI-MOC/obmd/token"
 )
 
 // Contents of the config file
@@ -26,7 +27,7 @@ type Config struct {
 	DBType     string
 	DBPath     string
 	ListenAddr string
-	AdminToken Token
+	AdminToken token.Token
 	Insecure   bool
 	TLSCert    string
 	TLSKey     string
@@ -50,7 +51,7 @@ func main() {
 
 	if *genToken {
 		// The user passed -gen-token; generate a token and exit.
-		var tok Token
+		var tok token.Token
 		_, err := rand.Read(tok[:])
 		chkfatal(err)
 		text, err := tok.MarshalText()

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"crypto/rand"
 	"database/sql"
 	"encoding/json"
 	"flag"
@@ -51,8 +50,7 @@ func main() {
 
 	if *genToken {
 		// The user passed -gen-token; generate a token and exit.
-		var tok token.Token
-		_, err := rand.Read(tok[:])
+		tok, err := token.New()
 		chkfatal(err)
 		text, err := tok.MarshalText()
 		chkfatal(err)

--- a/node.go
+++ b/node.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"crypto/rand"
-	"crypto/subtle"
 
 	"github.com/CCI-MOC/obmd/internal/driver"
 	"github.com/CCI-MOC/obmd/token"
@@ -47,7 +46,7 @@ func (n *Node) NewToken() (token.Token, error) {
 
 // Return whether a token is valid.
 func (n *Node) ValidToken(tok token.Token) bool {
-	return subtle.ConstantTimeCompare(n.CurrentToken[:], tok[:]) == 1
+	return n.CurrentToken.Verify(tok) == nil
 }
 
 // Clear any existing token, and disconnect any clients

--- a/node.go
+++ b/node.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"crypto/rand"
 
 	"github.com/CCI-MOC/obmd/internal/driver"
 	"github.com/CCI-MOC/obmd/token"
@@ -34,8 +33,7 @@ func NewNode(d driver.Driver, info []byte) (*Node, error) {
 // clients using it. If an error occurs, the state of the node/token will
 // be unchanged.
 func (n *Node) NewToken() (token.Token, error) {
-	var tok token.Token
-	_, err := rand.Read(tok[:])
+	tok, err := token.New()
 	if err != nil {
 		return tok, err
 	}

--- a/node.go
+++ b/node.go
@@ -15,7 +15,8 @@ type Node struct {
 	CurrentToken token.Token        // Token for regular user operations.
 }
 
-// Returns a new node with the given driver information, with no valid token.
+// Returns a new node with the given driver information. The token will be
+// freshly generated.
 func NewNode(d driver.Driver, info []byte) (*Node, error) {
 	tok, err := token.New()
 	if err != nil {

--- a/node.go
+++ b/node.go
@@ -38,7 +38,7 @@ func (n *Node) NewToken() (token.Token, error) {
 		return tok, err
 	}
 	n.ClearToken()
-	copy(n.CurrentToken[:], tok[:])
+	n.CurrentToken = tok
 	return n.CurrentToken, nil
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/CCI-MOC/obmd/internal/driver/mock"
+	"github.com/CCI-MOC/obmd/token"
 )
 
 // adminRequests is a sequence of admin-only requests that is used by various tests.
@@ -220,9 +221,9 @@ func TestPowerActions(t *testing.T) {
 			"pass": "secret"
 		}
 	}`)
-	token := getToken(t, handler, "somenode")
+	tok := getToken(t, handler, "somenode")
 
-	badToken, _ := Token{}.MarshalText() // All zeros
+	badToken, _ := token.Token{}.MarshalText() // All zeros
 
 	testCases := []struct {
 		context string
@@ -234,7 +235,7 @@ func TestPowerActions(t *testing.T) {
 		// Power off the node, and make sure that the operation went through.
 		{
 			"power off",
-			token,
+			tok,
 			http.StatusOK,
 			mock.Off,
 			requestSpec{"POST", "/node/somenode/power_off", ""},
@@ -242,7 +243,7 @@ func TestPowerActions(t *testing.T) {
 		// Power on the node, and make sure that the operation went through.
 		{
 			"power on",
-			token,
+			tok,
 			http.StatusOK,
 			mock.On,
 			requestSpec{"POST", "/node/somenode/power_on", ""},
@@ -260,7 +261,7 @@ func TestPowerActions(t *testing.T) {
 		// Now do it with the right token:
 		{
 			"power cycle (force, with good token)",
-			token,
+			tok,
 			http.StatusOK,
 			mock.ForceReboot,
 			requestSpec{
@@ -270,7 +271,7 @@ func TestPowerActions(t *testing.T) {
 		// Check the other operations:
 		{
 			"power cycle (soft, with good token)",
-			token,
+			tok,
 			http.StatusOK,
 			mock.SoftReboot,
 			requestSpec{
@@ -279,7 +280,7 @@ func TestPowerActions(t *testing.T) {
 		},
 		{
 			"set bootdev to A",
-			token,
+			tok,
 			http.StatusOK,
 			mock.BootDevA,
 			requestSpec{
@@ -288,7 +289,7 @@ func TestPowerActions(t *testing.T) {
 		},
 		{
 			"set bootdev to B",
-			token,
+			tok,
 			http.StatusOK,
 			mock.BootDevA,
 			requestSpec{
@@ -297,7 +298,7 @@ func TestPowerActions(t *testing.T) {
 		},
 		{
 			"set bootdev to something invalid.",
-			token,
+			tok,
 			http.StatusBadRequest,
 			mock.BootDevA, // should be unchanged.
 			requestSpec{

--- a/token/token.go
+++ b/token/token.go
@@ -20,28 +20,11 @@ var (
 // A cryptographically random 128-bit value.
 type Token [128 / 8]byte
 
-// A dummy token to be used when there is no "valid" token. This is
-// generated in init(), and never escapes the program. It exists so
-// we don't have to have special purpose logic for the case where
-// there is no correct token; we just set the node's token to this
-// value which is inaccessable to *anyone*.
-var noToken Token
-
-func init() {
-	if _, err := rand.Read(noToken[:]); err != nil {
-		panic(err)
-	}
-}
-
 // Generate a new, cryptographically random token.
 func New() (Token, error) {
 	var ret Token
 	_, err := rand.Read(ret[:])
 	return ret, err
-}
-
-func None() Token {
-	return noToken
 }
 
 func (t Token) MarshalText() ([]byte, error) {

--- a/token/token.go
+++ b/token/token.go
@@ -33,6 +33,13 @@ func init() {
 	}
 }
 
+// Generate a new, cryptographically random token.
+func New() (Token, error) {
+	var ret Token
+	_, err := rand.Read(ret[:])
+	return ret, err
+}
+
 func None() Token {
 	return noToken
 }

--- a/token/token.go
+++ b/token/token.go
@@ -1,10 +1,14 @@
-package main
+package token
 
 import (
 	"bytes"
 	"crypto/rand"
+	"errors"
 	"fmt"
 )
+
+// Error indicating that a token was malformed.
+var ErrInvalidToken = errors.New("Invalid token.")
 
 // A cryptographically random 128-bit value.
 type Token [128 / 8]byte
@@ -17,8 +21,13 @@ type Token [128 / 8]byte
 var noToken Token
 
 func init() {
-	_, err := rand.Read(noToken[:])
-	chkfatal(err)
+	if _, err := rand.Read(noToken[:]); err != nil {
+		panic(err)
+	}
+}
+
+func None() Token {
+	return noToken
 }
 
 func (t Token) MarshalText() ([]byte, error) {

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -1,4 +1,4 @@
-package main
+package token
 
 import (
 	"testing"


### PR DESCRIPTION
So we don't have to duplicate the logic in hil-vpn; there's some related discussion at https://github.com/CCI-MOC/hil-vpn/issues/4

Besides just moving it into a subdirectory where it can be imported, this also gets rid of the `noToken` mechanism; see the commit message for 4aa7e95.